### PR TITLE
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and Strin…

### DIFF
--- a/src/main/java/com/spring/mvc/mini/pojo/ObjectClassesType.java
+++ b/src/main/java/com/spring/mvc/mini/pojo/ObjectClassesType.java
@@ -16,7 +16,7 @@ public class ObjectClassesType {
 
     @Override
     public String toString() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (ObjectClass item : objectClasses) {
             sb.append(item);
         }

--- a/src/main/java/com/spring/mvc/mini/pojo/RequestStatusListType.java
+++ b/src/main/java/com/spring/mvc/mini/pojo/RequestStatusListType.java
@@ -17,7 +17,7 @@ public class RequestStatusListType {
 	@Override
 	public String toString() {
 		
-		StringBuffer s = new StringBuffer();
+		StringBuilder s = new StringBuilder();
 		for (RequestStatus r: requestStatuses){
 			s.append(r);
 		}

--- a/src/main/java/com/spring/mvc/mini/schedule/ScheduleFileUpdator.java
+++ b/src/main/java/com/spring/mvc/mini/schedule/ScheduleFileUpdator.java
@@ -76,7 +76,7 @@ public class ScheduleFileUpdator {
 
     private String appendCommitMessage(RequestStatus status) {
 
-        StringBuffer s = new StringBuffer();
+        StringBuilder s = new StringBuilder();
         s.append("Final approval of MO CR ");
         s.append(status.getmocrid());
         s.append(" for ");

--- a/src/main/java/com/spring/mvc/mini/web/ObjectClassFormController.java
+++ b/src/main/java/com/spring/mvc/mini/web/ObjectClassFormController.java
@@ -153,7 +153,7 @@ public class ObjectClassFormController {
     }
 
     private String constructMailText(@ModelAttribute("userinfo") UserInfo userinfo, @ModelAttribute("mocrid") String mocrid) {
-        StringBuffer textsb = new StringBuffer();
+        StringBuilder textsb = new StringBuilder();
         textsb.append("Hi,\r\n\r\nThese MO CR's shall be approved if no other comments.\r\nIf you have any comment, please comment on this page:\r\n");
         textsb.append("http://");
         textsb.append(webHostname);
@@ -170,7 +170,7 @@ public class ObjectClassFormController {
     }
 
     private String constructMailSubject(@ModelAttribute("mocrid") String mocrid, List<ObjectClass> objectClasses) {
-        StringBuffer subjectsb = new StringBuffer();
+        StringBuilder subjectsb = new StringBuilder();
         subjectsb.append("Forthcoming approval of MO CR ");
         subjectsb.append(mocrid);
         subjectsb.append(" for ");
@@ -181,7 +181,7 @@ public class ObjectClassFormController {
     }
 
     private void constructDebugMessage(List<ObjectClass> objectClasses) {
-        StringBuffer debugmessage = new StringBuffer();
+        StringBuilder debugmessage = new StringBuilder();
         for (ObjectClass objcls : objectClasses) {
             debugmessage.append(objcls);
         }

--- a/src/main/java/com/spring/mvc/mini/web/RequestStatusController.java
+++ b/src/main/java/com/spring/mvc/mini/web/RequestStatusController.java
@@ -118,7 +118,7 @@ public class RequestStatusController {
 	}
 
 	private String constructMailText(@ModelAttribute(REQUEST_STATUS) RequestStatus requestStatus, List<RequestStatus> requestStatuses, int index) {
-		StringBuffer textsb = new StringBuffer();
+		StringBuilder textsb = new StringBuilder();
 		textsb.append("New Comments: \r\n");
 		textsb.append(requestStatus.getComments());
 		textsb.append(" \r\n");
@@ -136,7 +136,7 @@ public class RequestStatusController {
 	}
 
 	private String constructMailSubject(@ModelAttribute(REQUEST_STATUS) RequestStatus requestStatus) {
-		StringBuffer subjectsb = new StringBuffer();
+		StringBuilder subjectsb = new StringBuilder();
 		subjectsb.append("MO CR:");
 		subjectsb.append(requestStatus.getmocrid());
 		subjectsb.append(" Updated");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1149

Please let me know if you have any questions.

M-Ezzat
