### PR TITLE
squid:S2325 - private methods that don't access instance data should …

### DIFF
--- a/src/main/java/com/spring/mvc/mini/schedule/ScheduleFileUpdator.java
+++ b/src/main/java/com/spring/mvc/mini/schedule/ScheduleFileUpdator.java
@@ -88,7 +88,7 @@ public class ScheduleFileUpdator {
         return s.toString();
     }
 
-    private void setCommitDateAndStatus(Date currentTime, List<RequestStatus> requestStatuses, RequestStatus status) {
+    private static void setCommitDateAndStatus(Date currentTime, List<RequestStatus> requestStatuses, RequestStatus status) {
         int requestStatusIndex;
         requestStatusIndex = requestStatuses.indexOf(status);
         requestStatuses.get(requestStatusIndex).setCommitDate(currentTime);

--- a/src/main/java/com/spring/mvc/mini/web/ObjectClassFormController.java
+++ b/src/main/java/com/spring/mvc/mini/web/ObjectClassFormController.java
@@ -180,7 +180,7 @@ public class ObjectClassFormController {
         return subjectsb.toString();
     }
 
-    private void constructDebugMessage(List<ObjectClass> objectClasses) {
+    private static void constructDebugMessage(List<ObjectClass> objectClasses) {
         StringBuilder debugmessage = new StringBuilder();
         for (ObjectClass objcls : objectClasses) {
             debugmessage.append(objcls);

--- a/src/main/java/com/spring/mvc/mini/web/ObjectClassesController.java
+++ b/src/main/java/com/spring/mvc/mini/web/ObjectClassesController.java
@@ -124,7 +124,7 @@ public class ObjectClassesController {
         }
     }
 
-    private int isInteger(String s) {
+    private static int isInteger(String s) {
         int i;
         try {
             i = Integer.parseInt(s);

--- a/src/main/java/com/spring/mvc/mini/xml/ObjectClassXMLPaser.java
+++ b/src/main/java/com/spring/mvc/mini/xml/ObjectClassXMLPaser.java
@@ -75,14 +75,14 @@ public class ObjectClassXMLPaser {
         return objectClasses;
     }
 
-    private ObjectClass setCommentToObject(Comment node) {
+    private static ObjectClass setCommentToObject(Comment node) {
         ObjectClass objectClass;
         objectClass = new ObjectClass();
         objectClass.setComment(node.getData());
         return objectClass;
     }
 
-    private void setElementToObject(ObjectClass objectClass, Element node) {
+    private static void setElementToObject(ObjectClass objectClass, Element node) {
         objectClass.setId(node.getAttribute("id"));
         objectClass.setAbbreviation(node.getAttribute("abbrev"));
         objectClass.setIntclass(Integer.parseInt(node.getAttribute("intclass")));
@@ -121,7 +121,7 @@ public class ObjectClassXMLPaser {
         }
     }
 
-    private Element getElementOfObjectClass(ObjectClass objectClass, Document document) {
+    private static Element getElementOfObjectClass(ObjectClass objectClass, Document document) {
         Element e = document.createElement("objclass");
         e.setAttribute("id", objectClass.getId());
         e.setAttribute("intclass", String.valueOf(objectClass.getIntclass()));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

M-Ezzat
