### PR TITLE
Cleanup - squid:S1943 - Classes and methods that rely on the default …

### DIFF
--- a/src/main/java/com/spring/mvc/mini/svn/SVNHandler.java
+++ b/src/main/java/com/spring/mvc/mini/svn/SVNHandler.java
@@ -14,6 +14,8 @@ import org.tmatesoft.svn.core.wc.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 
@@ -74,7 +76,7 @@ public class SVNHandler {
                     SVNDepth.INFINITY, true, outputStream, null);
 
             if (outputStream.size() > 0) {
-                commitClient.doCommit(xmlfilearray, false, outputStream.toString(), false, true);
+                commitClient.doCommit(xmlfilearray, false, outputStream.toString("UTF-8"), false, true);
                 LOG.info("XML Checked in at " + new Date());
             }
 
@@ -82,11 +84,11 @@ public class SVNHandler {
                     SVNDepth.INFINITY, true, outputStream, null);
 
             if (outputStream.size() > 0) {
-                commitClient.doCommit(jsonfilearray, false, outputStream.toString(), false, true);
+                commitClient.doCommit(jsonfilearray, false, outputStream.toString("UTF-8"), false, true);
                 LOG.info("Json SVN Checked in at " + new Date());
             }
 
-        } catch (SVNException e) {
+        } catch (SVNException|UnsupportedEncodingException e) {
             LOG.error(e.toString());
         } finally {
             ourClientManager.dispose();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat
